### PR TITLE
Fix color options generation

### DIFF
--- a/colores.js
+++ b/colores.js
@@ -12,10 +12,11 @@ const coloresPorProducto = {
   "Street Style Pro":     ["#34495e", "#7f8c8d", "#ecf0f1"]
 };
 
-document.addEventListener('DOMContentLoaded', () => {
+function inicializarColores() {
   document.querySelectorAll('.product-card').forEach(card => {
     const nombre = card.querySelector('.product-info h3').textContent.trim();
     const container = card.querySelector('.color-options');
+    if (!container) return;
     const colores = coloresPorProducto[nombre] || [];
 
     // limpia cualquier opción previa
@@ -30,5 +31,11 @@ document.addEventListener('DOMContentLoaded', () => {
       container.appendChild(div);
     });
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', inicializarColores);
+} else {
+  inicializarColores();
+}
 

--- a/productos.html
+++ b/productos.html
@@ -583,6 +583,7 @@
 
     <!-- Enlaza tu archivo JS aquí -->
          <script src="tallas.js"></script>
+    <script src="colores.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -185,32 +185,37 @@ document.querySelectorAll('.page-btn').forEach(btn => {
     });
 });
 
-// Selección de color en productos
-document.querySelectorAll('.color-options').forEach(options => {
-    options.querySelectorAll('.color-option').forEach(option => {
-        option.addEventListener('click', function() {
-            options.querySelectorAll('.color-option').forEach(opt => opt.classList.remove('selected-color'));
-            this.classList.add('selected-color');
+// Acciones que dependen del DOM completo
+window.addEventListener('DOMContentLoaded', () => {
+    // Selección de color en productos
+    document.querySelectorAll('.color-options').forEach(options => {
+        options.querySelectorAll('.color-option').forEach(option => {
+            option.addEventListener('click', function() {
+                options.querySelectorAll('.color-option').forEach(opt =>
+                    opt.classList.remove('selected-color'));
+                this.classList.add('selected-color');
+            });
         });
     });
-});
 
-// Al cargar la página, actualiza el contador
-updateCartCount();
-
-document.querySelectorAll('.product-card').forEach(card => {
-    const nameElem = card.querySelector('.product-info h3');
-    const select = card.querySelector('.size-select');
-    if (nameElem && select && typeof tallasPorProducto !== "undefined") {
-        const nombre = nameElem.textContent.trim();
-        const tallas = tallasPorProducto[nombre];
-        if (Array.isArray(tallas)) {
-            tallas.forEach(talla => {
-                const option = document.createElement('option');
-                option.value = talla;
-                option.textContent = talla;
-                select.appendChild(option);
-            });
+    // Llenar las tallas disponibles
+    document.querySelectorAll('.product-card').forEach(card => {
+        const nameElem = card.querySelector('.product-info h3');
+        const select = card.querySelector('.size-select');
+        if (nameElem && select && typeof tallasPorProducto !== 'undefined') {
+            const nombre = nameElem.textContent.trim();
+            const tallas = tallasPorProducto[nombre];
+            if (Array.isArray(tallas)) {
+                tallas.forEach(talla => {
+                    const option = document.createElement('option');
+                    option.value = talla;
+                    option.textContent = talla;
+                    select.appendChild(option);
+                });
+            }
         }
-    }
+    });
+
+    // Al cargar la página, actualiza el contador
+    updateCartCount();
 });


### PR DESCRIPTION
## Summary
- run color option generator regardless of DOM load state
- include `colores.js` on the products page

## Testing
- `npx eslint script.js tallas.js colores.js` *(fails: ESLint couldn't find a config)*
- `npx -y htmlhint index.html productos.html`

------
https://chatgpt.com/codex/tasks/task_b_68884cbf49f08331bfc1e553a9c0860d